### PR TITLE
Read credentials from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Or install it yourself as:
 
 ## Usage
 
-Create a new client passing in your [foauth][] email and password.
+Create a new client passing in your [foauth][] email and password. If
+you don't pass any credentials then it will look in the `FOAUTH_EMAIL`
+and `FOAUTH_PASSWORD` environment variables.
 
 ```ruby
 client = Foauth.new('bob@example.org', 'secret')

--- a/lib/foauth.rb
+++ b/lib/foauth.rb
@@ -10,7 +10,7 @@ module Foauth
   # @param [String] password Your foauth.org password.
   # @yield [builder] Passes the `Faraday::Builder` instance to the block if given.
   # @return [Faraday::Connection] Configured to proxy requests to foauth.org.
-  def self.new(email, password)
+  def self.new(email = ENV['FOAUTH_EMAIL'], password = ENV['FOAUTH_PASSWORD'])
     Faraday.new do |builder|
       builder.request :foauth_proxy
       builder.request :basic_auth, email, password

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -28,4 +28,21 @@ describe Foauth do
       expect(response.env['foo']).to eq 'bar'
     end
   end
+
+  describe "with environment varaibles" do
+    let(:client) do
+      ENV['FOAUTH_EMAIL'] = 'foo@example.org'
+      ENV['FOAUTH_PASSWORD'] = 'secret'
+      Foauth.new
+    end
+
+    after do
+      ENV.delete('FOAUTH_EMAIL')
+      ENV.delete('FOAUTH_PASSWORD')
+    end
+
+    it "authenticates with environment credentials" do
+      expect(request_headers['Authorization']).to eq 'Basic Zm9vQGV4YW1wbGUub3JnOnNlY3JldA=='
+    end
+  end
 end


### PR DESCRIPTION
When a new client is created it should read the environment variables `FOAUTH_EMAIL` and `FOAUTH_PASSWORD` if no email and password is given and use those instead.
